### PR TITLE
Placeholder removal, daily deals tab update

### DIFF
--- a/Views/DailyDealsView.swift
+++ b/Views/DailyDealsView.swift
@@ -12,29 +12,47 @@ struct DailyDealsView: View {
     private let foodTruckService = FoodTruckService()
 
     var body: some View {
-        NavigationView {
-            List(dailyDeals) { deal in
-                VStack(alignment: .leading) {
-                    Text(deal.name)
-                        .font(.headline)
-                    Text("Food Truck: \(deal.foodTruckName)") // lägga till namn food truck-a
-                        .font(.subheadline)
-                        .foregroundColor(.blue)
-                    Text("Original Price: \(deal.originalPrice, specifier: "%.2f")")
-                        .strikethrough()
-                    Text("Deal Price: \(deal.dealPrice, specifier: "%.2f")")
-                        .foregroundColor(.red)
-                    Text("Ingredients: \(deal.ingredients)")
-                        .font(.subheadline)
-                        .foregroundColor(.gray)
+        VStack {
+            Text("🎉 Daily Deals 🎉")
+                .font(.title)
+                .fontWeight(.heavy)
+                .foregroundColor(.red)
+                .padding(.vertical, 10)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .shadow(color: .black, radius: 1)
+
+            NavigationView {
+                List {
+                    ForEach(groupedDeals.keys.sorted(), id: \.self) { key in
+                        Section(header: Text(key).font(.headline)) {
+                            ForEach(groupedDeals[key] ?? []) { deal in
+                                VStack(alignment: .leading) {
+                                    Text(deal.name)
+                                        .font(.headline)
+                                    Text("Original Price: \(deal.originalPrice, specifier: "%.2f")")
+                                        .strikethrough()
+                                    Text("Deal Price: \(deal.dealPrice, specifier: "%.2f")")
+                                        .foregroundColor(.red)
+                                    Text("Ingredients: \(deal.ingredients)")
+                                        .font(.subheadline)
+                                        .foregroundColor(.gray)
+                                }
+                                .padding()
+                            }
+                        }
+                    }
                 }
-                .padding()
+                .navigationTitle("")
+                .navigationBarHidden(true)
             }
-            .navigationTitle("Dagens Deals")
+            .onAppear {
+                fetchAllDailyDeals()
+            }
         }
-        .onAppear {
-            fetchAllDailyDeals()
-        }
+    }
+
+    private var groupedDeals: [String: [DailyDealItem]] {
+        Dictionary(grouping: dailyDeals, by: { $0.foodTruckName })
     }
 
     private func fetchAllDailyDeals() {

--- a/Views/FoodTruckProfileView.swift
+++ b/Views/FoodTruckProfileView.swift
@@ -26,15 +26,17 @@ struct FoodTruckProfileView: View {
                     .padding(.top, 10)
                 
                 // Food truck image
-                AsyncImage(url: URL(string: viewModel.foodTruck.imageURL)) { image in
-                    image
-                        .resizable()
-                        .scaledToFill()
-                } placeholder: {
-                    Color.gray
+                if let imageURL = URL(string: viewModel.foodTruck.imageURL) {
+                    AsyncImage(url: imageURL) { image in
+                        image
+                            .resizable()
+                            .scaledToFill()
+                            .frame(width: UIScreen.main.bounds.width, height: 200)
+                            .clipped()
+                    } placeholder: {
+                        EmptyView()
+                    }
                 }
-                .frame(width: UIScreen.main.bounds.width, height: 200)
-                .clipped()
                 
                 // Rating bar
                 RatingView(rating: viewModel.foodTruck.rating)
@@ -45,13 +47,14 @@ struct FoodTruckProfileView: View {
                 
                 // Reviews Count and Average Rating
                 Text("(\(viewModel.foodTruck.ratings.count) ratings and \(viewModel.foodTruck.reviews.count) reviews)")
-                                    .foregroundColor(.blue)
-                                    .font(.footnote)
-                                    .padding(.bottom, 30)
-                                    .onTapGesture {
-                                        isReviewListPresented = true
-                                    }
-
+                    .foregroundColor(.blue)
+                    .font(.footnote)
+                    .padding(.bottom, 30)
+                    .onTapGesture {
+                        isReviewListPresented = true
+                    }
+                
+                // Information about the food truck.
                 VStack(alignment: .leading, spacing: 10) {
                     informationRow(title: "Food:", value: viewModel.foodTruck.foodType)
                     informationRow(title: "Price Range:", value: viewModel.foodTruck.priceRange)
@@ -122,6 +125,7 @@ struct FoodTruckProfileView: View {
                     }
                     .padding([.horizontal, .bottom])
                 }
+                
                 // Menu
                 Group {
                     VStack(alignment: .leading) {


### PR DESCRIPTION
1. Removed placeholder for images in FoodTruckProfileView if an owner doesn't want a picture - replaced with an empty view. 
2. Small appearance update in the Deals tab including grouped deals depending on which food truck that is shown.